### PR TITLE
docs: fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prisma generator for model factories.
 ## Getting started
 
 ```sh
-npm i @quramy/prisma-fabbrica --dev
+npm i @quramy/prisma-fabbrica -D
 ```
 
 Then, edit your `prisma/schema.prisma` and append the prisma-fabbrica generator configuration:


### PR DESCRIPTION
Corrected correctly as there is no "--dev" option.

docs: https://docs.npmjs.com/cli/v8/commands/npm-install
```
-D, --save-dev: Package will appear in your devDependencies.
```