### PR TITLE
docs: fix typo jset to jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ generator fabbrica {
 If you use [@quramy/jest-prisma](https://github.com/Quramy/jest-prisma) or [@quramy/jest-prisma-node](https://github.com/Quramy/jest-prisma/tree/main/packages/jest-prisma-node), you can pass `@quramy/prisma-fabbrica/scripts/jest-prisma` to `setupFilesAfterEnv` in your Jest configuration file.
 
 ```js
-/* jset.config.mjs */
+/* jest.config.mjs */
 
 export default {
   preset: "ts-jest",


### PR DESCRIPTION
Thank you for everything.
I am also impressed with the jest-prisma system you started and use.

I found a typo in the README that is `jset.config.mjs`, which is just a small thing this time, so I raised a PR to fix it.