### PR TITLE
fix: Ignore to generate unsupported model

### DIFF
--- a/packages/artifact-testing/fixtures/field-variation/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/field-variation/__generated__/fabbrica/index.ts
@@ -25,6 +25,9 @@ const modelFieldDefinitions: ModelWithFields[] = [{
     }, {
         name: "NoPkModel",
         fields: []
+    }, {
+        name: "UnsupportedModel",
+        fields: []
     }];
 
 type UserScalarOrEnumFields = {

--- a/packages/artifact-testing/fixtures/field-variation/schema.prisma
+++ b/packages/artifact-testing/fixtures/field-variation/schema.prisma
@@ -63,3 +63,8 @@ model FieldTypePatternModel {
 model NoPkModel {
   id Int @unique
 }
+
+model UnsupportedModel {
+  id               Int @id
+  unsupportedField Unsupported("tsvector")
+}

--- a/packages/prisma-fabbrica/src/templates/autoGenerateModelScalarsOrEnumsFieldArgs.test.ts
+++ b/packages/prisma-fabbrica/src/templates/autoGenerateModelScalarsOrEnumsFieldArgs.test.ts
@@ -173,7 +173,7 @@ describe(autoGenerateModelScalarsOrEnumsFieldArgs, () => {
   ])("generates expression node for $targetField", async ({ datamodel, targetField, expected }) => {
     const dmmf = await getDMMF({ datamodel });
     const model = dmmf.datamodel.models[0];
-    const field = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel").fields.find(f => f.name === targetField)!;
+    const field = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel")?.fields.find(f => f.name === targetField)!;
     const enums = dmmf.schema.enumTypes.model ?? [];
     expect(printNode(autoGenerateModelScalarsOrEnumsFieldArgs(model, field, enums))).toBe(expected.trim());
   });

--- a/packages/prisma-fabbrica/src/templates/modelScalarOrEnumFields.test.ts
+++ b/packages/prisma-fabbrica/src/templates/modelScalarOrEnumFields.test.ts
@@ -65,6 +65,7 @@ describe(modelScalarOrEnumFields, () => {
       datamodel,
     });
     const inputType = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel");
+    if (!inputType) fail();
     const source = template.statement(expected)();
     expect(printNode(modelScalarOrEnumFields(dmmf.datamodel.models[0], inputType))).toBe(printNode(source).trim());
   });
@@ -84,6 +85,7 @@ describe(modelScalarOrEnumFields, () => {
         id: number;
       }
     `();
+    if (!inputType) fail();
     expect(printNode(modelScalarOrEnumFields(dmmf.datamodel.models[0], inputType))).toBe(printNode(expected).trim());
   });
 });


### PR DESCRIPTION
It fixes #206 .

If Model has field definition annotated `Unsupported` type,  prisma-client-js generator omits to generate `.create` or `.update` method of the model. It means that  `ModelCreateInput` of this model struct cannot appear in DMMF.

ref: https://www.prisma.io/docs/concepts/components/prisma-schema/data-model#unsupported-types

So, we should not throw an error in `findPrsimaCreateInputTypeFromModelName` but skip to generate factory of this model.