### PR TITLE
fix: findPrsimaCreateInputTypeFromModelName method name typo

### DIFF
--- a/packages/prisma-fabbrica/src/templates/autoGenerateModelScalarsOrEnumsFieldArgs.test.ts
+++ b/packages/prisma-fabbrica/src/templates/autoGenerateModelScalarsOrEnumsFieldArgs.test.ts
@@ -1,7 +1,7 @@
 import { getDMMF } from "@prisma/internals";
 import { printNode } from "talt";
 
-import { autoGenerateModelScalarsOrEnumsFieldArgs, findPrsimaCreateInputTypeFromModelName } from ".";
+import { autoGenerateModelScalarsOrEnumsFieldArgs, findPrismaCreateInputTypeFromModelName } from ".";
 
 describe(autoGenerateModelScalarsOrEnumsFieldArgs, () => {
   it.each([
@@ -173,7 +173,7 @@ describe(autoGenerateModelScalarsOrEnumsFieldArgs, () => {
   ])("generates expression node for $targetField", async ({ datamodel, targetField, expected }) => {
     const dmmf = await getDMMF({ datamodel });
     const model = dmmf.datamodel.models[0];
-    const field = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel")?.fields.find(f => f.name === targetField)!;
+    const field = findPrismaCreateInputTypeFromModelName(dmmf, "TestModel")?.fields.find(f => f.name === targetField)!;
     const enums = dmmf.schema.enumTypes.model ?? [];
     expect(printNode(autoGenerateModelScalarsOrEnumsFieldArgs(model, field, enums))).toBe(expected.trim());
   });

--- a/packages/prisma-fabbrica/src/templates/index.ts
+++ b/packages/prisma-fabbrica/src/templates/index.ts
@@ -8,11 +8,11 @@ import { ast } from "./ast-tools/astShorthand";
 import { createJSONLiteral } from "./ast-tools/createJSONLiteral";
 import { wrapWithTSDoc, insertLeadingBreakMarker } from "./ast-tools/comment";
 
-export function findPrsimaCreateInputTypeFromModelName(document: DMMF.Document, modelName: string) {
+export function findPrismaCreateInputTypeFromModelName(document: DMMF.Document, modelName: string) {
   const search = `${modelName}CreateInput`;
   const inputType = document.schema.inputObjectTypes.prisma.find(x => x.name === search);
 
-  // When model has field annotated with Unsupportted type, Prisma omits to output ModelCreateInput / ModelUpdateInput to DMMF.
+  // When model has field annotated with Unsupported type, Prisma omits to output ModelCreateInput / ModelUpdateInput to DMMF.
   if (!inputType) return null;
 
   return inputType;
@@ -502,7 +502,7 @@ export function getSourceFile({
   ];
   const modelNames = document.datamodel.models
     .map(m => m.name)
-    .filter(modelName => findPrsimaCreateInputTypeFromModelName(document, modelName));
+    .filter(modelName => findPrismaCreateInputTypeFromModelName(document, modelName));
   const statements = [
     ...modelNames.map(modelName => importStatement(modelName, prismaClientModuleSpecifier)),
     ...modelEnums.map(enumName => importStatement(enumName, prismaClientModuleSpecifier)),
@@ -511,7 +511,7 @@ export function getSourceFile({
     insertLeadingBreakMarker(modelFieldDefinitions(document.datamodel.models)),
     ...document.datamodel.models
       .reduce((acc, model) => {
-        const createInputType = findPrsimaCreateInputTypeFromModelName(document, model.name);
+        const createInputType = findPrismaCreateInputTypeFromModelName(document, model.name);
         if (!createInputType) return acc;
         return [...acc, { model, createInputType }];
       }, [] as readonly { model: DMMF.Model; createInputType: DMMF.InputType }[])

--- a/packages/prisma-fabbrica/src/templates/modelScalarOrEnumFields.test.ts
+++ b/packages/prisma-fabbrica/src/templates/modelScalarOrEnumFields.test.ts
@@ -1,7 +1,7 @@
 import { getDMMF } from "@prisma/internals";
 import { template, printNode } from "talt";
 
-import { modelScalarOrEnumFields, findPrsimaCreateInputTypeFromModelName } from ".";
+import { modelScalarOrEnumFields, findPrismaCreateInputTypeFromModelName } from ".";
 
 describe(modelScalarOrEnumFields, () => {
   it.each([
@@ -64,7 +64,7 @@ describe(modelScalarOrEnumFields, () => {
     const dmmf = await getDMMF({
       datamodel,
     });
-    const inputType = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel");
+    const inputType = findPrismaCreateInputTypeFromModelName(dmmf, "TestModel");
     if (!inputType) fail();
     const source = template.statement(expected)();
     expect(printNode(modelScalarOrEnumFields(dmmf.datamodel.models[0], inputType))).toBe(printNode(source).trim());
@@ -79,7 +79,7 @@ describe(modelScalarOrEnumFields, () => {
         }
       `,
     });
-    const inputType = findPrsimaCreateInputTypeFromModelName(dmmf, "TestModel");
+    const inputType = findPrismaCreateInputTypeFromModelName(dmmf, "TestModel");
     const expected = template.sourceFile`
       type TestModelScalarOrEnumFields = {
         id: number;


### PR DESCRIPTION
# Summary

I fixed method name.

find**Prsima**CreateInputTypeFromModelName → find**Prisma**CreateInputTypeFromModelName

This is my first modified PR to OSS, so please close if I'm wrong.