### PR TITLE
wip: Callback options

### DIFF
--- a/examples/example-prj/src/__generated__/fabbrica/index.d.ts
+++ b/examples/example-prj/src/__generated__/fabbrica/index.d.ts
@@ -5,10 +5,15 @@ import type { Category } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import { Resolver } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-declare const factoryFor: unique symbol;
 type BuildDataOptions = {
     readonly seq: number;
 };
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
+};
+declare const factoryFor: unique symbol;
 type UserFactoryDefineInput = {
     id?: string;
     email?: string;
@@ -18,14 +23,15 @@ type UserFactoryDefineInput = {
     posts?: Prisma.PostCreateNestedManyWithoutAuthorInput;
     comments?: Prisma.CommentCreateNestedManyWithoutAuthorInput;
 };
+type UserFactoryTrait = {
+    data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 type UserFactoryDefineOptions = {
     defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: UserFactoryTrait;
     };
-};
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
 export interface UserFactoryInterfaceWithoutTraits {
     readonly [factoryFor]: "User";
@@ -60,14 +66,15 @@ type PostFactoryDefineInput = {
     comments?: Prisma.CommentCreateNestedManyWithoutPostInput;
     categories?: Prisma.CategoryCreateNestedManyWithoutPostsInput;
 };
+type PostFactoryTrait = {
+    data?: Resolver<Partial<PostFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Post, Prisma.PostCreateInput>;
 type PostFactoryDefineOptions = {
     defaultData: Resolver<PostFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<PostFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: PostFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Post, Prisma.PostCreateInput>;
 type PostTraitKeys<TOptions extends PostFactoryDefineOptions> = keyof TOptions["traits"];
 export interface PostFactoryInterfaceWithoutTraits {
     readonly [factoryFor]: "Post";
@@ -105,14 +112,15 @@ type CommentFactoryDefineInput = {
     post: CommentpostFactory | Prisma.PostCreateNestedOneWithoutCommentsInput;
     author: CommentauthorFactory | Prisma.UserCreateNestedOneWithoutCommentsInput;
 };
+type CommentFactoryTrait = {
+    data?: Resolver<Partial<CommentFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Comment, Prisma.CommentCreateInput>;
 type CommentFactoryDefineOptions = {
     defaultData: Resolver<CommentFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<CommentFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: CommentFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Comment, Prisma.CommentCreateInput>;
 type CommentTraitKeys<TOptions extends CommentFactoryDefineOptions> = keyof TOptions["traits"];
 export interface CommentFactoryInterfaceWithoutTraits {
     readonly [factoryFor]: "Comment";
@@ -139,14 +147,15 @@ type CategoryFactoryDefineInput = {
     name?: string;
     posts?: Prisma.PostCreateNestedManyWithoutCategoriesInput;
 };
+type CategoryFactoryTrait = {
+    data?: Resolver<Partial<CategoryFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Category, Prisma.CategoryCreateInput>;
 type CategoryFactoryDefineOptions = {
     defaultData?: Resolver<CategoryFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<CategoryFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: CategoryFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Category, Prisma.CategoryCreateInput>;
 type CategoryTraitKeys<TOptions extends CategoryFactoryDefineOptions> = keyof TOptions["traits"];
 export interface CategoryFactoryInterfaceWithoutTraits {
     readonly [factoryFor]: "Category";

--- a/examples/example-prj/src/__generated__/fabbrica/index.js
+++ b/examples/example-prj/src/__generated__/fabbrica/index.js
@@ -60,11 +60,23 @@ function autoGenerateUserScalarsOrEnums({ seq }) {
         name: (0, internal_1.getScalarFieldValueGenerator)().String({ modelName: "User", fieldName: "name", isId: false, isUnique: false, seq })
     };
 }
-function defineUserFactoryInternal({ defaultData: defaultDataResolver, traits: traitsDefs = {} }) {
+function defineUserFactoryInternal({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }) {
     const getFactoryWithTraits = (traitKeys = []) => {
         const seqKey = {};
         const getSeq = () => (0, internal_1.getSequenceCounter)(seqKey);
         const screen = (0, internal_1.createScreener)("User", modelFieldDefinitions);
+        const handleAfterBuild = (0, internal_1.createCallbackChain)([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = (0, internal_1.createCallbackChain)([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = (0, internal_1.createCallbackChain)([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
@@ -80,6 +92,7 @@ function defineUserFactoryInternal({ defaultData: defaultDataResolver, traits: t
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => build(data)));
@@ -88,7 +101,10 @@ function defineUserFactoryInternal({ defaultData: defaultDataResolver, traits: t
         });
         const create = async (inputData = {}) => {
             const data = await build(inputData).then(screen);
-            return await (0, internal_1.getClient)().user.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await (0, internal_1.getClient)().user.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => create(data)));
         const createForConnect = (inputData = {}) => create(inputData).then(pickForConnect);
@@ -131,11 +147,23 @@ function autoGeneratePostScalarsOrEnums({ seq }) {
         title: (0, internal_1.getScalarFieldValueGenerator)().String({ modelName: "Post", fieldName: "title", isId: false, isUnique: false, seq })
     };
 }
-function definePostFactoryInternal({ defaultData: defaultDataResolver, traits: traitsDefs = {} }) {
+function definePostFactoryInternal({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }) {
     const getFactoryWithTraits = (traitKeys = []) => {
         const seqKey = {};
         const getSeq = () => (0, internal_1.getSequenceCounter)(seqKey);
         const screen = (0, internal_1.createScreener)("Post", modelFieldDefinitions);
+        const handleAfterBuild = (0, internal_1.createCallbackChain)([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = (0, internal_1.createCallbackChain)([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = (0, internal_1.createCallbackChain)([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGeneratePostScalarsOrEnums({ seq });
@@ -155,6 +183,7 @@ function definePostFactoryInternal({ defaultData: defaultDataResolver, traits: t
                 } : defaultData.author
             };
             const data = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => build(data)));
@@ -163,7 +192,10 @@ function definePostFactoryInternal({ defaultData: defaultDataResolver, traits: t
         });
         const create = async (inputData = {}) => {
             const data = await build(inputData).then(screen);
-            return await (0, internal_1.getClient)().post.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await (0, internal_1.getClient)().post.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => create(data)));
         const createForConnect = (inputData = {}) => create(inputData).then(pickForConnect);
@@ -209,11 +241,23 @@ function autoGenerateCommentScalarsOrEnums({ seq }) {
         body: (0, internal_1.getScalarFieldValueGenerator)().String({ modelName: "Comment", fieldName: "body", isId: false, isUnique: false, seq })
     };
 }
-function defineCommentFactoryInternal({ defaultData: defaultDataResolver, traits: traitsDefs = {} }) {
+function defineCommentFactoryInternal({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }) {
     const getFactoryWithTraits = (traitKeys = []) => {
         const seqKey = {};
         const getSeq = () => (0, internal_1.getSequenceCounter)(seqKey);
         const screen = (0, internal_1.createScreener)("Comment", modelFieldDefinitions);
+        const handleAfterBuild = (0, internal_1.createCallbackChain)([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = (0, internal_1.createCallbackChain)([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = (0, internal_1.createCallbackChain)([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateCommentScalarsOrEnums({ seq });
@@ -236,6 +280,7 @@ function defineCommentFactoryInternal({ defaultData: defaultDataResolver, traits
                 } : defaultData.author
             };
             const data = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => build(data)));
@@ -244,7 +289,10 @@ function defineCommentFactoryInternal({ defaultData: defaultDataResolver, traits
         });
         const create = async (inputData = {}) => {
             const data = await build(inputData).then(screen);
-            return await (0, internal_1.getClient)().comment.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await (0, internal_1.getClient)().comment.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => create(data)));
         const createForConnect = (inputData = {}) => create(inputData).then(pickForConnect);
@@ -284,11 +332,23 @@ function autoGenerateCategoryScalarsOrEnums({ seq }) {
         name: (0, internal_1.getScalarFieldValueGenerator)().String({ modelName: "Category", fieldName: "name", isId: false, isUnique: true, seq })
     };
 }
-function defineCategoryFactoryInternal({ defaultData: defaultDataResolver, traits: traitsDefs = {} }) {
+function defineCategoryFactoryInternal({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }) {
     const getFactoryWithTraits = (traitKeys = []) => {
         const seqKey = {};
         const getSeq = () => (0, internal_1.getSequenceCounter)(seqKey);
         const screen = (0, internal_1.createScreener)("Category", modelFieldDefinitions);
+        const handleAfterBuild = (0, internal_1.createCallbackChain)([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = (0, internal_1.createCallbackChain)([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = (0, internal_1.createCallbackChain)([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateCategoryScalarsOrEnums({ seq });
@@ -304,6 +364,7 @@ function defineCategoryFactoryInternal({ defaultData: defaultDataResolver, trait
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => build(data)));
@@ -312,7 +373,10 @@ function defineCategoryFactoryInternal({ defaultData: defaultDataResolver, trait
         });
         const create = async (inputData = {}) => {
             const data = await build(inputData).then(screen);
-            return await (0, internal_1.getClient)().category.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await (0, internal_1.getClient)().category.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData) => Promise.all((0, internal_1.normalizeList)(inputData).map(data => create(data)));
         const createForConnect = (inputData = {}) => create(inputData).then(pickForConnect);

--- a/packages/artifact-testing/fixtures/callback/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/callback/__generated__/fabbrica/index.ts
@@ -1,11 +1,15 @@
 import type { User } from "../client";
 import { Prisma } from "../client";
 import type { PrismaClient } from "../client";
-import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-
 type BuildDataOptions = {
     readonly seq: number;
+};
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
 };
 
 const factoryFor = Symbol("factoryFor");
@@ -25,14 +29,16 @@ type UserFactoryDefineInput = {
     name?: string;
 };
 
+type UserFactoryTrait = {
+    data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+
 type UserFactoryDefineOptions = {
     defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: UserFactoryTrait;
     };
-};
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 
 type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
 
@@ -60,11 +66,23 @@ function autoGenerateUserScalarsOrEnums({ seq }: {
     };
 }
 
-function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("User", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
@@ -80,6 +98,7 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data: Prisma.UserCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -88,7 +107,10 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().user.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().user.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) => create(inputData).then(pickForConnect);

--- a/packages/artifact-testing/fixtures/callback/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/callback/__generated__/fabbrica/index.ts
@@ -1,0 +1,124 @@
+import type { User } from "../client";
+import { Prisma } from "../client";
+import type { PrismaClient } from "../client";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
+
+type BuildDataOptions = {
+    readonly seq: number;
+};
+
+const factoryFor = Symbol("factoryFor");
+
+const modelFieldDefinitions: ModelWithFields[] = [{
+        name: "User",
+        fields: []
+    }];
+
+type UserScalarOrEnumFields = {
+    id: string;
+    name: string;
+};
+
+type UserFactoryDefineInput = {
+    id?: string;
+    name?: string;
+};
+
+type UserFactoryDefineOptions = {
+    defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
+    traits?: {
+        [traitName: string | symbol]: {
+            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+        };
+    };
+};
+
+type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
+
+export interface UserFactoryInterfaceWithoutTraits {
+    readonly [factoryFor]: "User";
+    build(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+    buildCreateInput(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+    buildList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<Prisma.UserCreateInput[]>;
+    pickForConnect(inputData: User): Pick<User, "id">;
+    create(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<User>;
+    createList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<User[]>;
+    createForConnect(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Pick<User, "id">>;
+}
+
+export interface UserFactoryInterface<TOptions extends UserFactoryDefineOptions = UserFactoryDefineOptions> extends UserFactoryInterfaceWithoutTraits {
+    use(name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]): UserFactoryInterfaceWithoutTraits;
+}
+
+function autoGenerateUserScalarsOrEnums({ seq }: {
+    readonly seq: number;
+}): UserScalarOrEnumFields {
+    return {
+        id: getScalarFieldValueGenerator().String({ modelName: "User", fieldName: "id", isId: true, isUnique: false, seq }),
+        name: getScalarFieldValueGenerator().String({ modelName: "User", fieldName: "name", isId: false, isUnique: false, seq })
+    };
+}
+
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
+    const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
+        const seqKey = {};
+        const getSeq = () => getSequenceCounter(seqKey);
+        const screen = createScreener("User", modelFieldDefinitions);
+        const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+            const seq = getSeq();
+            const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
+            const resolveValue = normalizeResolver<UserFactoryDefineInput, BuildDataOptions>(defaultDataResolver ?? {});
+            const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+                const acc = await queue;
+                const resolveTraitValue = normalizeResolver<Partial<UserFactoryDefineInput>, BuildDataOptions>(traitsDefs[traitKey]?.data ?? {});
+                const traitData = await resolveTraitValue({ seq });
+                return {
+                    ...acc,
+                    ...traitData,
+                };
+            }, resolveValue({ seq }));
+            const defaultAssociations = {};
+            const data: Prisma.UserCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            return data;
+        };
+        const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
+        const pickForConnect = (inputData: User) => ({
+            id: inputData.id
+        });
+        const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+            const data = await build(inputData).then(screen);
+            return await getClient<PrismaClient>().user.create({ data });
+        };
+        const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
+        const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) => create(inputData).then(pickForConnect);
+        return {
+            [factoryFor]: "User" as const,
+            build,
+            buildList,
+            buildCreateInput: build,
+            pickForConnect,
+            create,
+            createList,
+            createForConnect,
+        };
+    };
+    const factory = getFactoryWithTraits();
+    const useTraits = (name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]) => {
+        return getFactoryWithTraits([name, ...names]);
+    };
+    return {
+        ...factory,
+        use: useTraits,
+    };
+}
+
+/**
+ * Define factory for {@link User} model.
+ *
+ * @param options
+ * @returns factory {@link UserFactoryInterface}
+ */
+export function defineUserFactory<TOptions extends UserFactoryDefineOptions>(options?: TOptions): UserFactoryInterface<TOptions> {
+    return defineUserFactoryInternal(options ?? {});
+}

--- a/packages/artifact-testing/fixtures/callback/fabbrica.modified.ts
+++ b/packages/artifact-testing/fixtures/callback/fabbrica.modified.ts
@@ -1,0 +1,198 @@
+import type { User } from "./__generated__/client";
+import { Prisma } from "./__generated__/client";
+import type { PrismaClient } from "./__generated__/client";
+import {
+  getClient,
+  ModelWithFields,
+  createScreener,
+  getScalarFieldValueGenerator,
+  Resolver,
+  normalizeResolver,
+  normalizeList,
+  getSequenceCounter,
+} from "@quramy/prisma-fabbrica/lib/internal";
+export {
+  initialize,
+  resetSequence,
+  registerScalarFieldValueGenerator,
+  resetScalarFieldValueGenerator,
+} from "@quramy/prisma-fabbrica/lib/internal";
+
+type BuildDataOptions = {
+  readonly seq: number;
+};
+
+type CallbackDefineOptions<TCreated, TCreateInput, TExtra = never> = {
+  onAfterBuild?: (createInput: TCreateInput, extra: TExtra) => void | PromiseLike<void>;
+  onBeforeCreate?: (createInput: TCreateInput, extra: TExtra) => void | PromiseLike<void>;
+  onAfterCreate?: (created: TCreated, extra: TExtra) => void | PromiseLike<void>;
+};
+
+const factoryFor = Symbol("factoryFor");
+
+const modelFieldDefinitions: ModelWithFields[] = [
+  {
+    name: "User",
+    fields: [],
+  },
+];
+
+function createCallbackChain<T extends any[]>(callbackFns: (((...args: T) => any) | undefined)[]) {
+  return async (...args: T) => {
+    await callbackFns.reduce(async (acc, fn) => {
+      await acc;
+      if (!fn) return;
+      await fn(...args);
+    }, Promise.resolve());
+  };
+}
+
+type UserScalarOrEnumFields = {
+  id: string;
+  name: string;
+};
+
+type UserFactoryDefineInput = {
+  id?: string;
+  name?: string;
+};
+
+type UserFactoryDefineOptions = {
+  defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
+  traits?: {
+    [traitName: string | symbol]: {
+      data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+    } & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+  };
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+
+type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
+
+export interface UserFactoryInterfaceWithoutTraits {
+  readonly [factoryFor]: "User";
+  build(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+  buildCreateInput(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+  buildList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<Prisma.UserCreateInput[]>;
+  pickForConnect(inputData: User): Pick<User, "id">;
+  create(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<User>;
+  createList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<User[]>;
+  createForConnect(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Pick<User, "id">>;
+}
+
+export interface UserFactoryInterface<TOptions extends UserFactoryDefineOptions = UserFactoryDefineOptions>
+  extends UserFactoryInterfaceWithoutTraits {
+  use(name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]): UserFactoryInterfaceWithoutTraits;
+}
+
+function autoGenerateUserScalarsOrEnums({ seq }: { readonly seq: number }): UserScalarOrEnumFields {
+  return {
+    id: getScalarFieldValueGenerator().String({ modelName: "User", fieldName: "id", isId: true, isUnique: false, seq }),
+    name: getScalarFieldValueGenerator().String({
+      modelName: "User",
+      fieldName: "name",
+      isId: false,
+      isUnique: false,
+      seq,
+    }),
+  };
+}
+
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({
+  defaultData: defaultDataResolver,
+  onAfterBuild,
+  onBeforeCreate,
+  onAfterCreate,
+  traits: traitsDefs = {},
+}: TOptions): UserFactoryInterface<TOptions> {
+  const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
+    const seqKey = {};
+    const getSeq = () => getSequenceCounter(seqKey);
+    const screen = createScreener("User", modelFieldDefinitions);
+    const handleAfterBuild = createCallbackChain([
+      onAfterBuild,
+      ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+    ]);
+    const handleBeforeCreate = createCallbackChain([
+      ...traitKeys
+        .slice()
+        .reverse()
+        .map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+      onBeforeCreate,
+    ]);
+    const handleAfterCreate = createCallbackChain([
+      onAfterCreate,
+      ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+    ]);
+    const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+      const seq = getSeq();
+      const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
+      const resolveValue = normalizeResolver<UserFactoryDefineInput, BuildDataOptions>(defaultDataResolver ?? {});
+      const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+        const acc = await queue;
+        const resolveTraitValue = normalizeResolver<Partial<UserFactoryDefineInput>, BuildDataOptions>(
+          traitsDefs[traitKey]?.data ?? {},
+        );
+        const traitData = await resolveTraitValue({ seq });
+        return {
+          ...acc,
+          ...traitData,
+        };
+      }, resolveValue({ seq }));
+      const defaultAssociations = {};
+      const data: Prisma.UserCreateInput = {
+        ...requiredScalarData,
+        ...defaultData,
+        ...defaultAssociations,
+        ...inputData,
+      };
+      await handleAfterBuild(data, null as never);
+      return data;
+    };
+    const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) =>
+      Promise.all(normalizeList(inputData).map(data => build(data)));
+    const pickForConnect = (inputData: User) => ({
+      id: inputData.id,
+    });
+    const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+      const data = await build(inputData).then(screen);
+      await handleBeforeCreate(data, null as never);
+      const created = await getClient<PrismaClient>().user.create({ data });
+      await handleAfterCreate(created, null as never);
+      return created;
+    };
+    const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) =>
+      Promise.all(normalizeList(inputData).map(data => create(data)));
+    const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) =>
+      create(inputData).then(pickForConnect);
+    return {
+      [factoryFor]: "User" as const,
+      build,
+      buildList,
+      buildCreateInput: build,
+      pickForConnect,
+      create,
+      createList,
+      createForConnect,
+    };
+  };
+  const factory = getFactoryWithTraits();
+  const useTraits = (name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]) => {
+    return getFactoryWithTraits([name, ...names]);
+  };
+  return {
+    ...factory,
+    use: useTraits,
+  };
+}
+
+/**
+ * Define factory for {@link User} model.
+ *
+ * @param options
+ * @returns factory {@link UserFactoryInterface}
+ */
+export function defineUserFactory<TOptions extends UserFactoryDefineOptions>(
+  options?: TOptions,
+): UserFactoryInterface<TOptions> {
+  return defineUserFactoryInternal(options ?? {});
+}

--- a/packages/artifact-testing/fixtures/callback/fabbrica.ts
+++ b/packages/artifact-testing/fixtures/callback/fabbrica.ts
@@ -1,0 +1,160 @@
+import type { User } from "./__generated__/client";
+import { Prisma } from "./__generated__/client";
+import type { PrismaClient } from "./__generated__/client";
+import {
+  getClient,
+  ModelWithFields,
+  createScreener,
+  getScalarFieldValueGenerator,
+  Resolver,
+  normalizeResolver,
+  normalizeList,
+  getSequenceCounter,
+} from "@quramy/prisma-fabbrica/lib/internal";
+export {
+  initialize,
+  resetSequence,
+  registerScalarFieldValueGenerator,
+  resetScalarFieldValueGenerator,
+} from "@quramy/prisma-fabbrica/lib/internal";
+
+type BuildDataOptions = {
+  readonly seq: number;
+};
+
+const factoryFor = Symbol("factoryFor");
+
+const modelFieldDefinitions: ModelWithFields[] = [
+  {
+    name: "User",
+    fields: [],
+  },
+];
+
+type UserScalarOrEnumFields = {
+  id: string;
+  name: string;
+};
+
+type UserFactoryDefineInput = {
+  id?: string;
+  name?: string;
+};
+
+type UserFactoryDefineOptions = {
+  defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
+  traits?: {
+    [traitName: string | symbol]: {
+      data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+    };
+  };
+};
+
+type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
+
+export interface UserFactoryInterfaceWithoutTraits {
+  readonly [factoryFor]: "User";
+  build(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+  buildCreateInput(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Prisma.UserCreateInput>;
+  buildList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<Prisma.UserCreateInput[]>;
+  pickForConnect(inputData: User): Pick<User, "id">;
+  create(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<User>;
+  createList(inputData: number | readonly Partial<Prisma.UserCreateInput>[]): PromiseLike<User[]>;
+  createForConnect(inputData?: Partial<Prisma.UserCreateInput>): PromiseLike<Pick<User, "id">>;
+}
+
+export interface UserFactoryInterface<TOptions extends UserFactoryDefineOptions = UserFactoryDefineOptions>
+  extends UserFactoryInterfaceWithoutTraits {
+  use(name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]): UserFactoryInterfaceWithoutTraits;
+}
+
+function autoGenerateUserScalarsOrEnums({ seq }: { readonly seq: number }): UserScalarOrEnumFields {
+  return {
+    id: getScalarFieldValueGenerator().String({ modelName: "User", fieldName: "id", isId: true, isUnique: false, seq }),
+    name: getScalarFieldValueGenerator().String({
+      modelName: "User",
+      fieldName: "name",
+      isId: false,
+      isUnique: false,
+      seq,
+    }),
+  };
+}
+
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({
+  defaultData: defaultDataResolver,
+  traits: traitsDefs = {},
+}: TOptions): UserFactoryInterface<TOptions> {
+  const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
+    const seqKey = {};
+    const getSeq = () => getSequenceCounter(seqKey);
+    const screen = createScreener("User", modelFieldDefinitions);
+    const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+      const seq = getSeq();
+      const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
+      const resolveValue = normalizeResolver<UserFactoryDefineInput, BuildDataOptions>(defaultDataResolver ?? {});
+      const defaultData = await traitKeys.reduce(async (queue, traitKey) => {
+        const acc = await queue;
+        const resolveTraitValue = normalizeResolver<Partial<UserFactoryDefineInput>, BuildDataOptions>(
+          traitsDefs[traitKey]?.data ?? {},
+        );
+        const traitData = await resolveTraitValue({ seq });
+        return {
+          ...acc,
+          ...traitData,
+        };
+      }, resolveValue({ seq }));
+      const defaultAssociations = {};
+      const data: Prisma.UserCreateInput = {
+        ...requiredScalarData,
+        ...defaultData,
+        ...defaultAssociations,
+        ...inputData,
+      };
+      return data;
+    };
+    const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) =>
+      Promise.all(normalizeList(inputData).map(data => build(data)));
+    const pickForConnect = (inputData: User) => ({
+      id: inputData.id,
+    });
+    const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
+      const data = await build(inputData).then(screen);
+      return await getClient<PrismaClient>().user.create({ data });
+    };
+    const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) =>
+      Promise.all(normalizeList(inputData).map(data => create(data)));
+    const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) =>
+      create(inputData).then(pickForConnect);
+    return {
+      [factoryFor]: "User" as const,
+      build,
+      buildList,
+      buildCreateInput: build,
+      pickForConnect,
+      create,
+      createList,
+      createForConnect,
+    };
+  };
+  const factory = getFactoryWithTraits();
+  const useTraits = (name: UserTraitKeys<TOptions>, ...names: readonly UserTraitKeys<TOptions>[]) => {
+    return getFactoryWithTraits([name, ...names]);
+  };
+  return {
+    ...factory,
+    use: useTraits,
+  };
+}
+
+/**
+ * Define factory for {@link User} model.
+ *
+ * @param options
+ * @returns factory {@link UserFactoryInterface}
+ */
+export function defineUserFactory<TOptions extends UserFactoryDefineOptions>(
+  options?: TOptions,
+): UserFactoryInterface<TOptions> {
+  return defineUserFactoryInternal(options ?? {});
+}

--- a/packages/artifact-testing/fixtures/callback/index.test.ts
+++ b/packages/artifact-testing/fixtures/callback/index.test.ts
@@ -1,0 +1,101 @@
+import type { PrismaClient, User } from "./__generated__/client";
+
+// TODO replace later
+// import { initialize, defineUserFactory } from "./__generated__/fabbrica";
+import { initialize, defineUserFactory } from "./fabbrica.modified";
+
+describe("Generated functions", () => {
+  beforeAll(() => {
+    const clientStub = {
+      user: { create: jest.fn().mockReturnValue({ id: "stub id", name: "stub name" } as User) },
+    } as unknown as PrismaClient;
+    initialize({ prisma: clientStub });
+  });
+
+  describe("callback", () => {
+    test("onAfterBuild", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterBuild: user => {
+          mock(user);
+        },
+      });
+      await UserFactory.build({ id: "id", name: "name" });
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "id", name: "name" });
+    });
+
+    test("onBeforeCreate", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onBeforeCreate: user => {
+          mock(user);
+        },
+      });
+      await UserFactory.create({ id: "id", name: "name" });
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "id", name: "name" });
+    });
+
+    test("onAfterCreate", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterCreate: user => {
+          mock(user);
+        },
+      });
+      await UserFactory.create();
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "stub id", name: "stub name" });
+    });
+
+    test("callback orders with traits", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterBuild: () => {
+          mock("factory default", "onAfterBuild");
+        },
+        onBeforeCreate: () => {
+          mock("factory default", "onBeforeCreate");
+        },
+        onAfterCreate: () => {
+          mock("factory default", "onAfterCreate");
+        },
+        traits: {
+          a: {
+            onAfterBuild: () => {
+              mock("trait a", "onAfterBuild");
+            },
+            onBeforeCreate: () => {
+              mock("trait a", "onBeforeCreate");
+            },
+            onAfterCreate: () => {
+              mock("trait a", "onAfterCreate");
+            },
+          },
+          b: {
+            onAfterBuild: () => {
+              mock("trait b", "onAfterBuild");
+            },
+            onBeforeCreate: () => {
+              mock("trait b", "onBeforeCreate");
+            },
+            onAfterCreate: () => {
+              mock("trait b", "onAfterCreate");
+            },
+          },
+        },
+      });
+      await UserFactory.use("a", "b").create();
+      expect(mock).toHaveBeenNthCalledWith(1, "factory default", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(2, "trait a", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(3, "trait b", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(4, "trait b", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(5, "trait a", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(6, "factory default", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(7, "factory default", "onAfterCreate");
+      expect(mock).toHaveBeenNthCalledWith(8, "trait a", "onAfterCreate");
+      expect(mock).toHaveBeenNthCalledWith(9, "trait b", "onAfterCreate");
+    });
+  });
+});

--- a/packages/artifact-testing/fixtures/callback/schema.prisma
+++ b/packages/artifact-testing/fixtures/callback/schema.prisma
@@ -1,0 +1,20 @@
+generator client {
+  provider = "prisma-client-js"
+  output   = "./__generated__/client"
+}
+
+generator fabbrica {
+  provider    = "prisma-fabbrica"
+  output      = "./__generated__/fabbrica"
+  noTranspile = true
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id    String @id
+  name  String
+}

--- a/packages/artifact-testing/fixtures/relations-many-to-many/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/relations-many-to-many/__generated__/fabbrica/index.ts
@@ -2,11 +2,15 @@ import type { Post } from "../client";
 import type { Category } from "../client";
 import { Prisma } from "../client";
 import type { PrismaClient } from "../client";
-import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-
 type BuildDataOptions = {
     readonly seq: number;
+};
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
 };
 
 const factoryFor = Symbol("factoryFor");
@@ -38,14 +42,16 @@ type PostFactoryDefineInput = {
     categories?: Prisma.CategoryCreateNestedManyWithoutPostsInput;
 };
 
+type PostFactoryTrait = {
+    data?: Resolver<Partial<PostFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Post, Prisma.PostCreateInput>;
+
 type PostFactoryDefineOptions = {
     defaultData?: Resolver<PostFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<PostFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: PostFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Post, Prisma.PostCreateInput>;
 
 type PostTraitKeys<TOptions extends PostFactoryDefineOptions> = keyof TOptions["traits"];
 
@@ -73,11 +79,23 @@ function autoGeneratePostScalarsOrEnums({ seq }: {
     };
 }
 
-function definePostFactoryInternal<TOptions extends PostFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): PostFactoryInterface<TOptions> {
+function definePostFactoryInternal<TOptions extends PostFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): PostFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly PostTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("Post", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.PostCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGeneratePostScalarsOrEnums({ seq });
@@ -93,6 +111,7 @@ function definePostFactoryInternal<TOptions extends PostFactoryDefineOptions>({ 
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data: Prisma.PostCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.PostCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -101,7 +120,10 @@ function definePostFactoryInternal<TOptions extends PostFactoryDefineOptions>({ 
         });
         const create = async (inputData: Partial<Prisma.PostCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().post.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().post.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.PostCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.PostCreateInput> = {}) => create(inputData).then(pickForConnect);
@@ -147,14 +169,16 @@ type CategoryFactoryDefineInput = {
     posts?: Prisma.PostCreateNestedManyWithoutCategoriesInput;
 };
 
+type CategoryFactoryTrait = {
+    data?: Resolver<Partial<CategoryFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Category, Prisma.CategoryCreateInput>;
+
 type CategoryFactoryDefineOptions = {
     defaultData?: Resolver<CategoryFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<CategoryFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: CategoryFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Category, Prisma.CategoryCreateInput>;
 
 type CategoryTraitKeys<TOptions extends CategoryFactoryDefineOptions> = keyof TOptions["traits"];
 
@@ -182,11 +206,23 @@ function autoGenerateCategoryScalarsOrEnums({ seq }: {
     };
 }
 
-function defineCategoryFactoryInternal<TOptions extends CategoryFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): CategoryFactoryInterface<TOptions> {
+function defineCategoryFactoryInternal<TOptions extends CategoryFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): CategoryFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly CategoryTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("Category", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.CategoryCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateCategoryScalarsOrEnums({ seq });
@@ -202,6 +238,7 @@ function defineCategoryFactoryInternal<TOptions extends CategoryFactoryDefineOpt
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data: Prisma.CategoryCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.CategoryCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -210,7 +247,10 @@ function defineCategoryFactoryInternal<TOptions extends CategoryFactoryDefineOpt
         });
         const create = async (inputData: Partial<Prisma.CategoryCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().category.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().category.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.CategoryCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.CategoryCreateInput> = {}) => create(inputData).then(pickForConnect);

--- a/packages/artifact-testing/fixtures/relations-one-to-one/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/relations-one-to-one/__generated__/fabbrica/index.ts
@@ -2,11 +2,15 @@ import type { User } from "../client";
 import type { Profile } from "../client";
 import { Prisma } from "../client";
 import type { PrismaClient } from "../client";
-import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-
 type BuildDataOptions = {
     readonly seq: number;
+};
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
 };
 
 const factoryFor = Symbol("factoryFor");
@@ -43,14 +47,16 @@ type UserFactoryDefineInput = {
     profile?: UserprofileFactory | Prisma.ProfileCreateNestedOneWithoutUserInput;
 };
 
+type UserFactoryTrait = {
+    data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+
 type UserFactoryDefineOptions = {
     defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: UserFactoryTrait;
     };
-};
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 
 function isUserprofileFactory(x: UserprofileFactory | Prisma.ProfileCreateNestedOneWithoutUserInput | undefined): x is UserprofileFactory {
     return (x as any)?.[factoryFor] === "Profile";
@@ -82,11 +88,23 @@ function autoGenerateUserScalarsOrEnums({ seq }: {
     };
 }
 
-function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("User", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
@@ -106,6 +124,7 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
                 } : defaultData.profile
             };
             const data: Prisma.UserCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -114,7 +133,10 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().user.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().user.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) => create(inputData).then(pickForConnect);
@@ -163,14 +185,16 @@ type ProfileFactoryDefineInput = {
     user: ProfileuserFactory | Prisma.UserCreateNestedOneWithoutProfileInput;
 };
 
+type ProfileFactoryTrait = {
+    data?: Resolver<Partial<ProfileFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<Profile, Prisma.ProfileCreateInput>;
+
 type ProfileFactoryDefineOptions = {
     defaultData: Resolver<ProfileFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<ProfileFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: ProfileFactoryTrait;
     };
-};
+} & CallbackDefineOptions<Profile, Prisma.ProfileCreateInput>;
 
 function isProfileuserFactory(x: ProfileuserFactory | Prisma.UserCreateNestedOneWithoutProfileInput | undefined): x is ProfileuserFactory {
     return (x as any)?.[factoryFor] === "User";
@@ -201,11 +225,23 @@ function autoGenerateProfileScalarsOrEnums({ seq }: {
     };
 }
 
-function defineProfileFactoryInternal<TOptions extends ProfileFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): ProfileFactoryInterface<TOptions> {
+function defineProfileFactoryInternal<TOptions extends ProfileFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): ProfileFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly ProfileTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("Profile", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.ProfileCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateProfileScalarsOrEnums({ seq });
@@ -225,6 +261,7 @@ function defineProfileFactoryInternal<TOptions extends ProfileFactoryDefineOptio
                 } : defaultData.user
             };
             const data: Prisma.ProfileCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.ProfileCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -233,7 +270,10 @@ function defineProfileFactoryInternal<TOptions extends ProfileFactoryDefineOptio
         });
         const create = async (inputData: Partial<Prisma.ProfileCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().profile.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().profile.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.ProfileCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.ProfileCreateInput> = {}) => create(inputData).then(pickForConnect);

--- a/packages/artifact-testing/fixtures/simple-model/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/simple-model/__generated__/fabbrica/index.ts
@@ -1,11 +1,15 @@
 import type { User } from "../client";
 import { Prisma } from "../client";
 import type { PrismaClient } from "../client";
-import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-
 type BuildDataOptions = {
     readonly seq: number;
+};
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
 };
 
 const factoryFor = Symbol("factoryFor");
@@ -25,14 +29,16 @@ type UserFactoryDefineInput = {
     name?: string;
 };
 
+type UserFactoryTrait = {
+    data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+
 type UserFactoryDefineOptions = {
     defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: UserFactoryTrait;
     };
-};
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 
 type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
 
@@ -60,11 +66,23 @@ function autoGenerateUserScalarsOrEnums({ seq }: {
     };
 }
 
-function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("User", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
@@ -80,6 +98,7 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data: Prisma.UserCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -88,7 +107,10 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().user.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().user.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) => create(inputData).then(pickForConnect);

--- a/packages/artifact-testing/fixtures/simple-model/callbacks.test.ts
+++ b/packages/artifact-testing/fixtures/simple-model/callbacks.test.ts
@@ -1,0 +1,107 @@
+import type { PrismaClient, User } from "./__generated__/client";
+
+import { initialize, defineUserFactory } from "./__generated__/fabbrica";
+
+describe("Generated functions", () => {
+  beforeAll(() => {
+    const clientStub = {
+      user: { create: jest.fn().mockReturnValue({ id: "stub id", name: "stub name" } as User) },
+    } as unknown as PrismaClient;
+    initialize({ prisma: clientStub });
+  });
+
+  describe("callback", () => {
+    test("onAfterBuild", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterBuild: user => {
+          mock(user);
+        },
+      });
+
+      await UserFactory.build({ id: "id", name: "name" });
+
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "id", name: "name" });
+    });
+
+    test("onBeforeCreate", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onBeforeCreate: user => {
+          mock(user);
+        },
+      });
+
+      await UserFactory.create({ id: "id", name: "name" });
+
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "id", name: "name" });
+    });
+
+    test("onAfterCreate", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterCreate: user => {
+          mock(user);
+        },
+      });
+
+      await UserFactory.create();
+
+      expect(mock).toBeCalledTimes(1);
+      expect(mock).toBeCalledWith({ id: "stub id", name: "stub name" });
+    });
+
+    test("callback orders with traits", async () => {
+      const mock = jest.fn();
+      const UserFactory = defineUserFactory({
+        onAfterBuild: () => {
+          mock("factory default", "onAfterBuild");
+        },
+        onBeforeCreate: () => {
+          mock("factory default", "onBeforeCreate");
+        },
+        onAfterCreate: () => {
+          mock("factory default", "onAfterCreate");
+        },
+        traits: {
+          a: {
+            onAfterBuild: () => {
+              mock("trait a", "onAfterBuild");
+            },
+            onBeforeCreate: () => {
+              mock("trait a", "onBeforeCreate");
+            },
+            onAfterCreate: () => {
+              mock("trait a", "onAfterCreate");
+            },
+          },
+          b: {
+            onAfterBuild: () => {
+              mock("trait b", "onAfterBuild");
+            },
+            onBeforeCreate: () => {
+              mock("trait b", "onBeforeCreate");
+            },
+            onAfterCreate: () => {
+              mock("trait b", "onAfterCreate");
+            },
+          },
+        },
+      });
+
+      await UserFactory.use("a", "b").create();
+
+      expect(mock).toHaveBeenNthCalledWith(1, "factory default", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(2, "trait a", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(3, "trait b", "onAfterBuild");
+      expect(mock).toHaveBeenNthCalledWith(4, "trait b", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(5, "trait a", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(6, "factory default", "onBeforeCreate");
+      expect(mock).toHaveBeenNthCalledWith(7, "factory default", "onAfterCreate");
+      expect(mock).toHaveBeenNthCalledWith(8, "trait a", "onAfterCreate");
+      expect(mock).toHaveBeenNthCalledWith(9, "trait b", "onAfterCreate");
+    });
+  });
+});

--- a/packages/prisma-fabbrica/src/helpers/callback.ts
+++ b/packages/prisma-fabbrica/src/helpers/callback.ts
@@ -1,0 +1,11 @@
+export type CallbackFn<T extends any[]> = (...args: T) => unknown;
+
+export function createCallbackChain<T extends any[]>(callbackFns: readonly (CallbackFn<T> | undefined)[]) {
+  return async (...args: T) => {
+    await callbackFns.reduce(async (acc, fn) => {
+      await acc;
+      if (!fn) return;
+      await fn(...args);
+    }, Promise.resolve());
+  };
+}

--- a/packages/prisma-fabbrica/src/helpers/index.ts
+++ b/packages/prisma-fabbrica/src/helpers/index.ts
@@ -3,3 +3,4 @@ export * from "./stringConverter";
 export * from "./sequence";
 export * from "./selectors";
 export * from "./list";
+export * from "./callback";

--- a/packages/prisma-fabbrica/src/internal.ts
+++ b/packages/prisma-fabbrica/src/internal.ts
@@ -1,6 +1,6 @@
 export { getClient } from "./clientHolder";
 export { ModelWithFields, createScreener } from "./relations/screen";
-export { Resolver, normalizeResolver, normalizeList, getSequenceCounter } from "./helpers";
+export { Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain } from "./helpers";
 export { initialize, resetSequence } from "./initialize";
 export {
   getScalarFieldValueGenerator,

--- a/packages/prisma-fabbrica/src/templates/__snapshots__/getSourceFile.test.ts.snap
+++ b/packages/prisma-fabbrica/src/templates/__snapshots__/getSourceFile.test.ts.snap
@@ -4,11 +4,15 @@ exports[`getSourceFile generates TypeScript AST 1`] = `
 "import type { User } from "@prisma/client";
 import { Prisma } from "@prisma/client";
 import type { PrismaClient } from "@prisma/client";
-import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, } from "@quramy/prisma-fabbrica/lib/internal";
+import { getClient, ModelWithFields, createScreener, getScalarFieldValueGenerator, Resolver, normalizeResolver, normalizeList, getSequenceCounter, createCallbackChain, } from "@quramy/prisma-fabbrica/lib/internal";
 export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
-
 type BuildDataOptions = {
     readonly seq: number;
+};
+type CallbackDefineOptions<TCreated, TCreateInput> = {
+    onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+    onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
 };
 
 const factoryFor = Symbol("factoryFor");
@@ -28,14 +32,16 @@ type UserFactoryDefineInput = {
     name?: string;
 };
 
+type UserFactoryTrait = {
+    data?: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
+
 type UserFactoryDefineOptions = {
     defaultData?: Resolver<UserFactoryDefineInput, BuildDataOptions>;
     traits?: {
-        [traitName: string | symbol]: {
-            data: Resolver<Partial<UserFactoryDefineInput>, BuildDataOptions>;
-        };
+        [traitName: string | symbol]: UserFactoryTrait;
     };
-};
+} & CallbackDefineOptions<User, Prisma.UserCreateInput>;
 
 type UserTraitKeys<TOptions extends UserFactoryDefineOptions> = keyof TOptions["traits"];
 
@@ -63,11 +69,23 @@ function autoGenerateUserScalarsOrEnums({ seq }: {
     };
 }
 
-function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
+function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ defaultData: defaultDataResolver, onAfterBuild, onBeforeCreate, onAfterCreate, traits: traitsDefs = {} }: TOptions): UserFactoryInterface<TOptions> {
     const getFactoryWithTraits = (traitKeys: readonly UserTraitKeys<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener("User", modelFieldDefinitions);
+        const handleAfterBuild = createCallbackChain([
+            onAfterBuild,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+            ...traitKeys.slice().reverse().map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+            onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+            onAfterCreate,
+            ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
         const build = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const seq = getSeq();
             const requiredScalarData = autoGenerateUserScalarsOrEnums({ seq });
@@ -83,6 +101,7 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
             }, resolveValue({ seq }));
             const defaultAssociations = {};
             const data: Prisma.UserCreateInput = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData };
+            await handleAfterBuild(data);
             return data;
         };
         const buildList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => build(data)));
@@ -91,7 +110,10 @@ function defineUserFactoryInternal<TOptions extends UserFactoryDefineOptions>({ 
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput> = {}) => {
             const data = await build(inputData).then(screen);
-            return await getClient<PrismaClient>().user.create({ data });
+            await handleBeforeCreate(data);
+            const createdData = await getClient<PrismaClient>().user.create({ data });
+            await handleAfterCreate(createdData);
+            return createdData;
         };
         const createList = (inputData: number | readonly Partial<Prisma.UserCreateInput>[]) => Promise.all(normalizeList(inputData).map(data => create(data)));
         const createForConnect = (inputData: Partial<Prisma.UserCreateInput> = {}) => create(inputData).then(pickForConnect);

--- a/packages/prisma-fabbrica/src/templates/ast-tools/comment.ts
+++ b/packages/prisma-fabbrica/src/templates/ast-tools/comment.ts
@@ -17,8 +17,16 @@ export function wrapWithTSDoc<T extends ts.Node>(text: string, node: T): T {
   );
 }
 
-export function insertLeadingBreakMarker<T extends ts.Node>(node: T): T {
-  const comments = ts.getSyntheticLeadingComments(node);
-  if (comments?.length) return node;
-  return ts.addSyntheticLeadingComment(node, ts.SyntaxKind.SingleLineCommentTrivia, "%BR%", true);
+function isNodeArray(x: any): x is ts.NodeArray<any> {
+  return Array.isArray(x);
+}
+
+export function insertLeadingBreakMarker<T extends ts.Node | ts.NodeArray<any>>(node: T): T {
+  if (!isNodeArray(node)) {
+    const comments = ts.getSyntheticLeadingComments(node);
+    if (comments?.length) return node;
+    return ts.addSyntheticLeadingComment(node, ts.SyntaxKind.SingleLineCommentTrivia, "%BR%", true) as T;
+  } else {
+    return node as T;
+  }
 }

--- a/packages/prisma-fabbrica/src/templates/index.ts
+++ b/packages/prisma-fabbrica/src/templates/index.ts
@@ -89,14 +89,21 @@ export const header = (prismaClientModuleSpecifier: string) =>
       normalizeResolver,
       normalizeList,
       getSequenceCounter,
+      createCallbackChain,
     } from "@quramy/prisma-fabbrica/lib/internal";
     export { initialize, resetSequence, registerScalarFieldValueGenerator, resetScalarFieldValueGenerator } from "@quramy/prisma-fabbrica/lib/internal";
   `();
 
-export const buildDataOptions = () =>
-  template.statement<ts.TypeAliasDeclaration>`
+export const genericTypeDeclarations = () =>
+  template.sourceFile`
     type BuildDataOptions = {
       readonly seq: number;
+    };
+
+    type CallbackDefineOptions<TCreated, TCreateInput> = {
+      onAfterBuild?: (createInput: TCreateInput) => void | PromiseLike<void>;
+      onBeforeCreate?: (createInput: TCreateInput) => void | PromiseLike<void>;
+      onAfterCreate?: (created: TCreated) => void | PromiseLike<void>;
     };
   `();
 
@@ -224,31 +231,42 @@ export const modelFactoryDefineInput = (model: DMMF.Model, inputType: DMMF.Input
     MODEL_FACTORY_DEFINE_INPUT: ast.identifier(`${model.name}FactoryDefineInput`),
   });
 
-export const modelFactoryDefineOptions = (modelName: string, isOpionalDefaultData: boolean) => {
+export const modelFactoryTrait = (model: DMMF.Model) =>
+  template.statement<ts.TypeAliasDeclaration>`
+    type MODEL_FACTORY_TRAIT = {
+      data?: Resolver<Partial<MODEL_FACTORY_DEFINE_INPUT>, BuildDataOptions>;
+    } & CallbackDefineOptions<MODEL_TYPE, Prisma.MODEL_CREATE_INPUT>;
+  `({
+    MODEL_TYPE: ast.identifier(model.name),
+    MODEL_CREATE_INPUT: ast.identifier(`${model.name}CreateInput`),
+    MODEL_FACTORY_DEFINE_INPUT: ast.identifier(`${model.name}FactoryDefineInput`),
+    MODEL_FACTORY_TRAIT: ast.identifier(`${model.name}FactoryTrait`),
+  });
+
+export const modelFactoryDefineOptions = (model: DMMF.Model, isOpionalDefaultData: boolean) => {
   const compiled = isOpionalDefaultData
     ? template.statement<ts.TypeAliasDeclaration>`
         type MODEL_FACTORY_DEFINE_OPTIONS = {
           defaultData?: Resolver<MODEL_FACTORY_DEFINE_INPUT, BuildDataOptions>;
           traits?: {
-            [traitName: string | symbol]: { 
-              data: Resolver<Partial<MODEL_FACTORY_DEFINE_INPUT>, BuildDataOptions>;
-            }
+            [traitName: string | symbol]: MODEL_FACTORY_TRAIT;
           };
-        };
+        } & CallbackDefineOptions<MODEL_TYPE, Prisma.MODEL_CREATE_INPUT>;
       `
     : template.statement<ts.TypeAliasDeclaration>`
         type MODEL_FACTORY_DEFINE_OPTIONS = {
           defaultData: Resolver<MODEL_FACTORY_DEFINE_INPUT, BuildDataOptions>;
           traits?: {
-            [traitName: string | symbol]: { 
-              data: Resolver<Partial<MODEL_FACTORY_DEFINE_INPUT>, BuildDataOptions>;
-            }
+            [traitName: string | symbol]: MODEL_FACTORY_TRAIT;
           };
-        };
+        } & CallbackDefineOptions<MODEL_TYPE, Prisma.MODEL_CREATE_INPUT>;
       `;
   return compiled({
-    MODEL_FACTORY_DEFINE_OPTIONS: ast.identifier(`${modelName}FactoryDefineOptions`),
-    MODEL_FACTORY_DEFINE_INPUT: ast.identifier(`${modelName}FactoryDefineInput`),
+    MODEL_TYPE: ast.identifier(model.name),
+    MODEL_CREATE_INPUT: ast.identifier(`${model.name}CreateInput`),
+    MODEL_FACTORY_DEFINE_INPUT: ast.identifier(`${model.name}FactoryDefineInput`),
+    MODEL_FACTORY_TRAIT: ast.identifier(`${model.name}FactoryTrait`),
+    MODEL_FACTORY_DEFINE_OPTIONS: ast.identifier(`${model.name}FactoryDefineOptions`),
   });
 };
 
@@ -355,12 +373,31 @@ export const defineModelFactoryInternal = (model: DMMF.Model, inputType: DMMF.In
   template.statement<ts.FunctionDeclaration>`
     function DEFINE_MODEL_FACTORY_INTERNAL<TOptions extends MODEL_FACTORY_DEFINE_OPTIONS>({
       defaultData: defaultDataResolver,
+      onAfterBuild,
+      onBeforeCreate,
+      onAfterCreate,
       traits: traitsDefs = {}
     }: TOptions): MODEL_FACTORY_INTERFACE<TOptions> {
       const getFactoryWithTraits = (traitKeys: readonly MODEL_TRAIT_KEYS<TOptions>[] = []) => {
         const seqKey = {};
         const getSeq = () => getSequenceCounter(seqKey);
         const screen = createScreener(${() => ast.stringLiteral(model.name)}, modelFieldDefinitions);
+
+        const handleAfterBuild = createCallbackChain([
+          onAfterBuild,
+          ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterBuild),
+        ]);
+        const handleBeforeCreate = createCallbackChain([
+          ...traitKeys
+            .slice()
+            .reverse()
+            .map(traitKey => traitsDefs[traitKey].onBeforeCreate),
+          onBeforeCreate,
+        ]);
+        const handleAfterCreate = createCallbackChain([
+          onAfterCreate,
+          ...traitKeys.map(traitKey => traitsDefs[traitKey].onAfterCreate),
+        ]);
 
         const build = async (
           inputData: Partial<Prisma.MODEL_CREATE_INPUT> = {}
@@ -395,6 +432,7 @@ export const defineModelFactoryInternal = (model: DMMF.Model, inputType: DMMF.In
               true,
             )};
           const data: Prisma.MODEL_CREATE_INPUT = { ...requiredScalarData, ...defaultData, ...defaultAssociations, ...inputData};
+          await handleAfterBuild(data);
           return data;
         };
 
@@ -416,7 +454,10 @@ export const defineModelFactoryInternal = (model: DMMF.Model, inputType: DMMF.In
           inputData: Partial<Prisma.MODEL_CREATE_INPUT> = {}
         ) => {
           const data = await build(inputData).then(screen);
-          return await getClient<PrismaClient>().MODEL_KEY.create({ data });
+          await handleBeforeCreate(data);
+          const createdData = await getClient<PrismaClient>().MODEL_KEY.create({ data });
+          await handleAfterCreate(createdData);
+          return createdData;
         };
 
         const createList = (
@@ -512,7 +553,7 @@ export function getSourceFile({
     ...modelNames.map(modelName => importStatement(modelName, prismaClientModuleSpecifier)),
     ...modelEnums.map(enumName => importStatement(enumName, prismaClientModuleSpecifier)),
     ...header(prismaClientModuleSpecifier).statements,
-    insertLeadingBreakMarker(buildDataOptions()),
+    ...insertLeadingBreakMarker(genericTypeDeclarations().statements),
     insertLeadingBreakMarker(symbols()),
     insertLeadingBreakMarker(modelFieldDefinitions(document.datamodel.models)),
     ...document.datamodel.models
@@ -527,7 +568,8 @@ export function getSourceFile({
           modelBelongsToRelationFactory(fieldType, model),
         ),
         modelFactoryDefineInput(model, createInputType),
-        modelFactoryDefineOptions(model.name, filterRequiredInputObjectTypeField(createInputType).length === 0),
+        modelFactoryTrait(model),
+        modelFactoryDefineOptions(model, filterRequiredInputObjectTypeField(createInputType).length === 0),
         ...filterBelongsToField(model, createInputType).map(fieldType => isModelAssociationFactory(fieldType, model)),
         modelTraitKeys(model),
         modelFactoryInterfaceWithoutTraits(model),


### PR DESCRIPTION
## What

Related #42 

### factories API

Add new options ,`onAfterBuild`, `onBeforeCreate`, and `onAfterCreate` such as:

```ts
const UserFactory = defineUserFactory({
  onAfterBuild: (userCreateInput) => {
    // do something
  },
  onBeforeCreate: (userCreateInput) => {
    // do something
  },
  onAfterCreate: (createdUser) => {
    // do something
  },
});
```

- `userCreateInput` is assignable to `Primsa.CreateUserInput` (parameter type of `prisma.user.create`)
- `createdUser` is assignable to `User` ( return type of `prisma.user.create` )
