### PR TITLE
docs: Fix bug in syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ Default filling rule also can be overwritten.
 
 ```ts
 const UserFactory = defineUserFactory({
-  defaultData: async () => {
+  defaultData: async () => ({
     email: await generateRandomEmailAddress(),
-  }
+  })
 })
 
 await UserFactory.create()


### PR DESCRIPTION
Fixes a minor bug/typo in the instructions in the README