### PR TITLE
fix: create() with default data and transient fields

### DIFF
--- a/examples/example-prj/src/__generated__/fabbrica/index.js
+++ b/examples/example-prj/src/__generated__/fabbrica/index.js
@@ -106,8 +106,8 @@ function defineUserFactoryInternal({ defaultData: defaultDataResolver, onAfterBu
             id: inputData.id
         });
         const create = async (inputData = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = (0, internal_1.destructure)(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient().user.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -193,8 +193,8 @@ function defineLoginLogFactoryInternal({ defaultData: defaultDataResolver, onAft
             id: inputData.id
         });
         const create = async (inputData = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = (0, internal_1.destructure)(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient().loginLog.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -287,8 +287,8 @@ function definePostFactoryInternal({ defaultData: defaultDataResolver, onAfterBu
             id: inputData.id
         });
         const create = async (inputData = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = (0, internal_1.destructure)(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient().post.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -387,8 +387,8 @@ function defineCommentFactoryInternal({ defaultData: defaultDataResolver, onAfte
             id: inputData.id
         });
         const create = async (inputData = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = (0, internal_1.destructure)(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient().comment.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -474,8 +474,8 @@ function defineCategoryFactoryInternal({ defaultData: defaultDataResolver, onAft
             id: inputData.id
         });
         const create = async (inputData = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = (0, internal_1.destructure)(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient().category.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/examples/example-prj/src/transient.test.ts
+++ b/examples/example-prj/src/transient.test.ts
@@ -6,7 +6,13 @@ const LoginLogFactory = defineLoginLogFactory();
 
 const UserFactory = defineUserFactory.withTransientFields({
   loginCount: 0,
+  emailDomain: "example.com",
 })({
+  defaultData: ({ emailDomain }) => {
+    return {
+      email: `test@${emailDomain}`,
+    };
+  },
   onAfterCreate: async (user, { loginCount }) => {
     await LoginLogFactory.createList(loginCount, { userId: user.id });
   },
@@ -24,6 +30,12 @@ describe("factories", () => {
           },
         }),
       ).resolves.toBe(3);
+    });
+
+    test("default data with transient filed", async () => {
+      const user = await UserFactory.create({ emailDomain: "example.test" });
+
+      expect(user.email).toBe("test@example.test");
     });
   });
 });

--- a/packages/artifact-testing/fixtures/field-variation/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/field-variation/__generated__/fabbrica/index.ts
@@ -139,8 +139,8 @@ function defineEnumModelFactoryInternal<TTransients extends Record<string, unkno
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.EnumModelCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().enumModel.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -280,8 +280,8 @@ function defineComplexIdModelFactoryInternal<TTransients extends Record<string, 
             lastName: inputData.lastName
         });
         const create = async (inputData: Partial<Prisma.ComplexIdModelCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().complexIdModel.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -451,8 +451,8 @@ function defineFieldTypePatternModelFactoryInternal<TTransients extends Record<s
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.FieldTypePatternModelCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().fieldTypePatternModel.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -588,8 +588,8 @@ function defineNoPkModelFactoryInternal<TTransients extends Record<string, unkno
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.NoPkModelCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().noPkModel.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/artifact-testing/fixtures/relations-many-to-many/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/relations-many-to-many/__generated__/fabbrica/index.ts
@@ -133,8 +133,8 @@ function definePostFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.PostCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().post.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -274,8 +274,8 @@ function defineCategoryFactoryInternal<TTransients extends Record<string, unknow
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.CategoryCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().category.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/artifact-testing/fixtures/relations-one-to-many/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/relations-one-to-many/__generated__/fabbrica/index.ts
@@ -154,8 +154,8 @@ function defineUserFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().user.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -309,8 +309,8 @@ function definePostFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.PostCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().post.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -476,8 +476,8 @@ function defineReviewFactoryInternal<TTransients extends Record<string, unknown>
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.ReviewCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().review.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/artifact-testing/fixtures/relations-one-to-one/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/relations-one-to-one/__generated__/fabbrica/index.ts
@@ -146,8 +146,8 @@ function defineUserFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().user.create({ data });
             await handleAfterCreate(createdData, transientFields);
@@ -297,8 +297,8 @@ function defineProfileFactoryInternal<TTransients extends Record<string, unknown
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.ProfileCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().profile.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/artifact-testing/fixtures/simple-model/__generated__/fabbrica/index.ts
+++ b/packages/artifact-testing/fixtures/simple-model/__generated__/fabbrica/index.ts
@@ -120,8 +120,8 @@ function defineUserFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().user.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/prisma-fabbrica/src/templates/__snapshots__/getSourceFile.test.ts.snap
+++ b/packages/prisma-fabbrica/src/templates/__snapshots__/getSourceFile.test.ts.snap
@@ -123,8 +123,8 @@ function defineUserFactoryInternal<TTransients extends Record<string, unknown>, 
             id: inputData.id
         });
         const create = async (inputData: Partial<Prisma.UserCreateInput & TTransients> = {}) => {
+            const data = await build({ ...inputData }).then(screen);
             const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-            const data = await build(inputData).then(screen);
             await handleBeforeCreate(data, transientFields);
             const createdData = await getClient<PrismaClient>().user.create({ data });
             await handleAfterCreate(createdData, transientFields);

--- a/packages/prisma-fabbrica/src/templates/index.ts
+++ b/packages/prisma-fabbrica/src/templates/index.ts
@@ -470,8 +470,8 @@ export const defineModelFactoryInternal = (model: DMMF.Model, inputType: DMMF.In
         const create = async (
           inputData: CREATE_INPUT_TYPE = {}
         ) => {
+          const data = await build({ ...inputData }).then(screen);
           const [transientFields] = destructure(defaultTransientFieldValues, inputData);
-          const data = await build(inputData).then(screen);
           await handleBeforeCreate(data, transientFields);
           const createdData = await getClient<PrismaClient>().MODEL_KEY.create({ data });
           await handleAfterCreate(createdData, transientFields);


### PR DESCRIPTION
Thank you for the great library.
This PR will fix the following problem.

Problem: defaultData() does not receive transient fields when using `factory.create({ transientFieldFoo: "something" })`
