### PR TITLE
fix: append "/index.js" to Prisma client import

### DIFF
--- a/packages/prisma-fabbrica/src/getClientModuleSpecifier.test.ts
+++ b/packages/prisma-fabbrica/src/getClientModuleSpecifier.test.ts
@@ -5,11 +5,23 @@ describe(getClientModuleSpecifier, () => {
     { outputDirname: "dist", clientGeneratorOutputPath: undefined, expected: "@prisma/client" },
     { outputDirname: "dist", clientGeneratorOutputPath: "node_modules/@prisma/client", expected: "@prisma/client" },
     { outputDirname: "dist", clientGeneratorOutputPath: "node_modules\\@prisma\\client", expected: "@prisma/client" },
-    { outputDirname: "dist", clientGeneratorOutputPath: "prisma-client", expected: "../prisma-client" },
-    { outputDirname: "dist", clientGeneratorOutputPath: "../prisma-client", expected: "../../prisma-client" },
-    { outputDirname: "./dist", clientGeneratorOutputPath: "../prisma-client", expected: "../../prisma-client" },
-    { outputDirname: ".\\dist", clientGeneratorOutputPath: "..\\prisma-client", expected: "../../prisma-client" },
-    { outputDirname: "dist", clientGeneratorOutputPath: "..\\..\\prisma-client", expected: "../../../prisma-client" },
+    { outputDirname: "dist", clientGeneratorOutputPath: "prisma-client", expected: "../prisma-client/index.js" },
+    { outputDirname: "dist", clientGeneratorOutputPath: "../prisma-client", expected: "../../prisma-client/index.js" },
+    {
+      outputDirname: "./dist",
+      clientGeneratorOutputPath: "../prisma-client",
+      expected: "../../prisma-client/index.js",
+    },
+    {
+      outputDirname: ".\\dist",
+      clientGeneratorOutputPath: "..\\prisma-client",
+      expected: "../../prisma-client/index.js",
+    },
+    {
+      outputDirname: "dist",
+      clientGeneratorOutputPath: "..\\..\\prisma-client",
+      expected: "../../../prisma-client/index.js",
+    },
   ])(
     "outputDirname: $outputDirname, clientGeneratorOutputPath: $clientGeneratorOutputPath, expected: $expected",
     ({ outputDirname, clientGeneratorOutputPath, expected }) => {

--- a/packages/prisma-fabbrica/src/getClientModuleSpecifier.ts
+++ b/packages/prisma-fabbrica/src/getClientModuleSpecifier.ts
@@ -13,6 +13,6 @@ export function getClientModuleSpecifier(clientGeneratorOutputPath: string | und
     .normalize(clientGeneratorOutputPosixPath)
     .endsWith(["node_modules", "@prisma", "client"].join(path.sep))
     ? "@prisma/client"
-    : path.normalize("./" + path.relative(outputPosixDirname, clientGeneratorOutputPosixPath));
+    : path.normalize(path.join(".", path.relative(outputPosixDirname, clientGeneratorOutputPosixPath), "index.js"));
   return prismaClientModuleSpecifier;
 }


### PR DESCRIPTION
fix #450

Fix import error when specifying output path of prisma client and using ES Modules.