### PR TITLE
Update peer dependency for @prisma/client to include v7

### DIFF
--- a/packages/prisma-fabbrica/package.json
+++ b/packages/prisma-fabbrica/package.json
@@ -43,7 +43,7 @@
     "talt": "2.4.4"
   },
   "peerDependencies": {
-    "@prisma/client": "^5.0.0 || ^6.0.0",
+    "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
With prisma 7 released, it would be great if this package were updated to work with it.